### PR TITLE
Swap items in a dictionary (7 kyu)

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -780,3 +780,41 @@ console.log(isValidIP('1.2.3.4 '));
 console.log(isValidIP('12.34.56.-7'));
 console.log(isValidIP('1.2.3.4\n'));
 console.log(isValidIP('\n1.2.3.4'));
+
+// Swap items in a dictionary (7 kyu)
+
+/* 
+In this kata, you will take the keys and values of an object and swap them around.
+
+You will be given a dictionary, and then you will want to return a dictionary with the old values as the keys,
+and list the old keys as values under their original keys.
+
+For example, given the dictionary: {'Ice': 'Cream', 'Age': '21', 'Light': 'Cream', 'Double': 'Cream'},
+
+you should return: {'Cream': ['Ice', 'Double', 'Light'], '21': ['Age']}
+
+Notes:
+The dictionary given will only contain strings
+The dictionary given will not be empty
+You do not have to sort the items in the lists
+*/
+
+function switchDict(dic) {
+
+	const newObj = {};
+
+	for (let key in dic) {
+
+		if (!newObj.hasOwnProperty(dic[key])) {
+			newObj[dic[key]] = [key];
+		} else {
+			newObj[dic[key]].push(key);
+		}
+
+	}
+
+	return newObj;
+}
+
+console.log(switchDict({ 'Ice': 'Cream', 'Age': '21', 'Light': 'Cream', 'Double': 'Cream' }));
+console.log(switchDict({ 'Ice': 'Cream', 'Heavy': 'Cream', 'Light': 'Cream', 'Double': 'Cream' }));


### PR DESCRIPTION
In this kata, you will take the keys and values of an object and swap them around.

You will be given a dictionary, and then you will want to return a dictionary with the old values as the keys,
and list the old keys as values under their original keys.

For example, given the dictionary: {'Ice': 'Cream', 'Age': '21', 'Light': 'Cream', 'Double': 'Cream'},

you should return: {'Cream': ['Ice', 'Double', 'Light'], '21': ['Age']}

Notes:
The dictionary given will only contain strings
The dictionary given will not be empty
You do not have to sort the items in the lists